### PR TITLE
add DiagnocticInfo head file for fixing ninja build

### DIFF
--- a/enzyme/Enzyme/Enzyme.cpp
+++ b/enzyme/Enzyme/Enzyme.cpp
@@ -61,6 +61,7 @@
 
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Constants.h"
+#include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstrTypes.h"


### PR DESCRIPTION
When I try to build ClangEnzyme-23.so, the output messages are:

/home/xys/Reactant/enzyme/Enzyme/Enzyme.cpp:754:33: error: use of undeclared identifier 'DiagnosticInfoUnsupported'
  754 |         M.getContext().diagnose(DiagnosticInfoUnsupported(
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.

I have add the DiagnocticInfo head file to fix it