### PR TITLE
Remove nvidia specific attribute generated by Clang when backend is rocm

### DIFF
--- a/enzyme/WORKSPACE
+++ b/enzyme/WORKSPACE
@@ -7,7 +7,7 @@ new_local_repository(
 
 load("@llvm-raw//utils/bazel:configure.bzl", "llvm_configure")
 
-llvm_configure(name = "llvm-project", targets = ["AArch64", "NVPTX", "X86", "AMDGPU"])
+llvm_configure(name = "llvm-project", targets = ["AArch64", "NVPTX", "X86"])
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")


### PR DESCRIPTION
Try to remove these warnings

'sm_52' is not a recognized processor for this target (ignoring processor)
'+ptx81' is not a recognized feature for this target (ignoring feature)
'+sm_52' is not a recognized feature for this target (ignoring feature)
'sm_52' is not a recognized processor for this target (ignoring processor)
'sm_52' is not a recognized processor for this target (ignoring processor)
'+ptx81' is not a recognized feature for this target (ignoring feature)
'+sm_52' is not a recognized feature for this target (ignoring feature)
'sm_52' is not a recognized processor for this target (ignoring processor)